### PR TITLE
Added openjdk 9, 10 and 11 extensions. Changed runtime to gnome and sdk to gnome

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Community.json
+++ b/com.jetbrains.IntelliJ-IDEA-Community.json
@@ -1,22 +1,48 @@
 {
   "app-id": "com.jetbrains.IntelliJ-IDEA-Community",
   "command": "idea",
-  "runtime": "org.freedesktop.Sdk",
-  "runtime-version": "18.08",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "3.30",
   "separate-locales": false,
-  "sdk": "org.freedesktop.Sdk",
-  "finish-args": [
-    "--device=all",
-    "--device=dri",
-    "--env=IDEA_JDK=/app/idea-IC/jre64/",
-    "--env=IDEA_VM_OPTIONS=/app/idea-IC/bin/idea64.vmoptions",
-    "--filesystem=host",
-    "--share=ipc",
-    "--share=network",
-    "--socket=x11",
-    "--talk-name=org.freedesktop.Notifications",
-    "--talk-name=org.freedesktop.secrets"
+  "sdk": "org.gnome.Sdk",
+  "sdk-extensions": [
+    "org.freedesktop.Sdk.Extension.openjdk9",
+    "org.freedesktop.Sdk.Extension.openjdk10",
+    "org.freedesktop.Sdk.Extension.openjdk11"
   ],
+  "finish-args" : [
+        "--require-version=0.10.0",
+        "--allow=devel",
+        "--talk-name=org.freedesktop.Flatpak",
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--filesystem=home",
+        "--filesystem=host",
+        "--share=network",
+        "--talk-name=org.gtk.vfs.*",
+        "--system-talk-name=org.freedesktop.PolicyKit1",
+        "--system-talk-name=org.gnome.Sysprof2",
+        "--talk-name=org.gnome.CodeAssist.v1.*",
+        "--filesystem=xdg-run/dconf",
+        "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+        "--system-talk-name=org.freedesktop.Avahi",
+        "--talk-name=org.freedesktop.FileManager1",
+        "--talk-name=org.gnome.SettingsDaemon.Color",
+        "--talk-name=org.freedesktop.PackageKit",
+        "--talk-name=org.freedesktop.secrets",
+        "--filesystem=xdg-run/keyring",
+        "--filesystem=~/.local/share/flatpak",
+        "--filesystem=xdg-data/meson",
+        "--filesystem=/var/lib/flatpak",
+        "--env=G_SLICE=always-malloc"
+],
+"x-run-args" : [
+        "--standalone",
+        "-vvvv"
+],
   "modules": [
     "shared-modules/gtk2/gtk2.json",
     {


### PR DESCRIPTION
Hello all,

Could you review these changes? I changed the runtime and sdk but they could easily be set back to the freedesktop versions if preferred. I chose Gnome since I use Gnome, but I understand not everyone wants it. I added the extensions for openjdk 9, 10, and 11. After a quick test I found there was an issue with 9 that was preventing me from setting it up as an SDK in the project default settings. I was able to build a simple hello world java application based on the JDK 10 and had no problem running it in the IDE. the openjdk 11 SDK was also able to be setup so I felt it will likely work. The extensions have to be specified in the manifest in order to be used in the flatpack is my understanding. In order to specify them in the manifest file, I had to install them so I would need to look into how to automatically do that. There are some switch settings I made in the finish section, and added some of what Gnome people do with their flatpaks, especially the builder project. The other reason I chose Gnome Runtime and SDK is the libsecret is included when you do, so you should be able to drop installing the full GTK2+. I'll try that tomorrow maybe.