### PR TITLE
intellij idea community edition release 2019.2.1

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Community.appdata.xml
+++ b/com.jetbrains.IntelliJ-IDEA-Community.appdata.xml
@@ -37,6 +37,7 @@
   <update_contact>community-support@jetbrains.com</update_contact>
   <content_rating type="oars-1.1" />
   <releases>
+    <release type="stable" date="2019-08-21" version="2019.2.1" />
     <release type="stable" date="2019-07-24" version="2019.2.0" />
     <release type="stable" date="2019-05-28" version="2019.1.3" />
     <release type="stable" date="2019-05-08" version="2019.1.2" />

--- a/com.jetbrains.IntelliJ-IDEA-Community.json
+++ b/com.jetbrains.IntelliJ-IDEA-Community.json
@@ -54,8 +54,8 @@
       "sources": [
         {
           "type": "file",
-          "sha256": "cc864979bd63cfb3c23f7ec79decc95bbd99dbef62c5a6ca6d3328053a6eb37a",
-          "url": "https://download.jetbrains.com/idea/ideaIC-2019.2.tar.gz"
+          "sha256": "2310f9714182e50a881fec4c9d498a04dfbb57f3cd9461383d35014fb1b778dd",
+          "url": "https://download.jetbrains.com/idea/ideaIC-2019.2.1.tar.gz"
         }, {
           "type": "file",
           "path": "com.jetbrains.IntelliJ-IDEA-Community.appdata.xml"


### PR DESCRIPTION
```shell
==> JetBrains IntelliJ IDEA (Community Edition)
Date: 2019-08-21
Version: 2019.2.1
Link: https://download.jetbrains.com/idea/ideaIC-2019.2.1.tar.gz
Size: 702192905
Checksum: 2310f9714182e50a881fec4c9d498a04dfbb57f3cd9461383d35014fb1b778dd
Upgrade needed – expected: 2019.2, actual: 2019.2.1
```