### PR TITLE
intellij idea community edition release 2019.3.0

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Community.appdata.xml
+++ b/com.jetbrains.IntelliJ-IDEA-Community.appdata.xml
@@ -37,6 +37,7 @@
   <update_contact>community-support@jetbrains.com</update_contact>
   <content_rating type="oars-1.1" />
   <releases>
+    <release type="stable" date="2019-11-28" version="2019.3.0" />
     <release type="stable" date="2019-10-29" version="2019.2.4" />
     <release type="stable" date="2019-09-24" version="2019.2.3" />
     <release type="stable" date="2019-09-06" version="2019.2.2" />

--- a/com.jetbrains.IntelliJ-IDEA-Community.json
+++ b/com.jetbrains.IntelliJ-IDEA-Community.json
@@ -41,7 +41,7 @@
       "buildsystem": "simple",
       "build-commands": [
         "install --directory --mode=0755 /app/idea-IC/",
-        "tar --directory=/app/idea-IC/ --extract --file=ideaIC-2019.2.4.tar.gz --gunzip --strip-components=1",
+        "tar --directory=/app/idea-IC/ --extract --file=ideaIC-2019.3.tar.gz --gunzip --strip-components=1",
         "install -D --mode=0644 /app/idea-IC/bin/idea.svg /app/share/icons/hicolor/scalable/apps/com.jetbrains.IntelliJ-IDEA-Community.svg",
         "install -D --mode=0755 entrypoint.sh /app/bin/idea",
         "install -D --mode=0644 --target-directory=/app/share/applications/ com.jetbrains.IntelliJ-IDEA-Community.desktop",
@@ -53,8 +53,8 @@
           "path": "entrypoint.sh"
         }, {
           "type": "file",
-          "sha256": "f871d4b9b23e0676a653bb9fdf80e8cfb970ddc835b1e7dc2be84dd329ab5b04",
-          "url": "https://download.jetbrains.com/idea/ideaIC-2019.2.4.tar.gz"
+          "sha256": "b2ebb30adffbde61cefe63598206b7b0a8e99bc4037130aca2c291c563fd4a60",
+          "url": "https://download.jetbrains.com/idea/ideaIC-2019.3.tar.gz"
         }, {
           "type": "file",
           "path": "com.jetbrains.IntelliJ-IDEA-Community.appdata.xml"


### PR DESCRIPTION
```shell
==> JetBrains IntelliJ IDEA (Community Edition)
Link: https://download.jetbrains.com/idea/ideaIC-2019.3.tar.gz
Checksum: b2ebb30adffbde61cefe63598206b7b0a8e99bc4037130aca2c291c563fd4a60
Size: 660551848
Version: 2019.3
Date: 2019-11-28
Upgrade needed! Flatpak version: 2019.2.4, released version: 2019.3
```