### PR TITLE
Kotlin Native: fix building due to libtinfo.so.5 missing

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Community.json
+++ b/com.jetbrains.IntelliJ-IDEA-Community.json
@@ -16,7 +16,8 @@
         "--socket=x11",
         "--talk-name=org.freedesktop.Flatpak",
         "--talk-name=org.freedesktop.Notifications",
-        "--talk-name=org.freedesktop.secrets"
+        "--talk-name=org.freedesktop.secrets",
+        "--env=LD_LIBRARY_PATH=/app/lib/"
     ],
     "modules": [
         "shared-modules/libsecret/libsecret.json",
@@ -29,7 +30,8 @@
                 "install -D --mode=0644 /app/idea-IC/bin/idea.svg /app/share/icons/hicolor/scalable/apps/com.jetbrains.IntelliJ-IDEA-Community.svg",
                 "install -D --mode=0755 entrypoint.sh /app/bin/idea",
                 "install -D --mode=0644 --target-directory=/app/share/applications/ com.jetbrains.IntelliJ-IDEA-Community.desktop",
-                "install -D --mode=0644 --target-directory=/app/share/metainfo/ com.jetbrains.IntelliJ-IDEA-Community.appdata.xml"
+                "install -D --mode=0644 --target-directory=/app/share/metainfo/ com.jetbrains.IntelliJ-IDEA-Community.appdata.xml",
+                "ln -s /usr/lib/x86_64-linux-gnu/libtinfo.so /app/lib/libtinfo.so.5"
             ],
             "sources": [
                 {


### PR DESCRIPTION
I wanted to try out Kotlin native but when you compile a native application it currently fails with:

`Compilation failed: The /home/$USER/.konan/dependencies/clang-llvm-8.0.0-linux-x86-64/bin/clang++ command returned non-zero exit code: 127.`

I checked manually why it was failing and it could not find `libtinfo.so.5`:

```
flatpak run --command=bash com.jetbrains.IntelliJ-IDEA-Community
/home/$USER/.konan/dependencies/clang-llvm-8.0.0-linux-x86-64/bin/clang++
/home/$USER/.konan/dependencies/clang-llvm-8.0.0-linux-x86-64/bin/clang++: error while loading shared libraries: libtinfo.so.5: cannot open shared object file: No such file or directory
```

What solved it was creating a symlink to `libtinfo.so.6` and setting `LD_LIBRARY_PATH` to `/app/lib/` and this should make it globally available for all SDKs installed through IDEA (old and new). I've tested it with JVM projects and it doesn't seem to interfere.