### PR TITLE
Add AppMenu to finish args and fix typo in build instructions

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -16,7 +16,7 @@ Assuming `flatpak`, `flatpak-builder`, and `git` are installed, then execute the
 $ git clone https://github.com/flathub/com.jetbrains.IntelliJ-IDEA-Community.git
 $ cd com.jetbrains.IntelliJ-IDEA-Community/
 $ flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
-$ flatpak-builder build --force-clean --install-deps-from=flathub --install --user com.jetbrains.IntelliJ-IDEA-Community.yml
+$ flatpak-builder build --force-clean --install-deps-from=flathub --install --user com.jetbrains.IntelliJ-IDEA-Community.yaml
 
 # ...to uninstall the artifact
 $ flatpak uninstall --delete-data --user com.jetbrains.IntelliJ-IDEA-Community

--- a/com.jetbrains.IntelliJ-IDEA-Community.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Community.yaml
@@ -19,6 +19,7 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.gnome.keyring.SystemPrompter
+  - --talk-name=com.canonical.AppMenu.Registrar
 modules:
   - shared-modules/libsecret/libsecret.json
 


### PR DESCRIPTION
This pull request adds a new entry to the finish args to enable Global Menu widgets from kde and xfce to recognize the intellij's global menu and integrate them.
In this branch I also fixed a typo in the build documentation, due to yml, being migrated to yaml.

Image 1: Example without the new finish args
![Screenshot_20220530_152823](https://user-images.githubusercontent.com/51462138/171045123-076c40c3-c67c-4710-856d-16ecfdbfb01f.png)

Image 2: Example with the new finish args
![Screenshot_20220530_152326](https://user-images.githubusercontent.com/51462138/171045140-1545bb47-a198-4aad-959d-dc17e0de0bef.png)

