### PR TITLE
Add persist .java to store license agreements

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -28,3 +28,8 @@ $ flatpak remote-delete --user flathub
 ----
 
 // git submodule foreach git pull origin master
+
+== Restricting the default permissions
+:flatseal-flathub: https://flathub.org/apps/details/com.github.tchx84.Flatseal
+
+When using {flatseal-flathub}[Flatseal] or `flatpak override` to restrict the default filesystem access, it is recommended to add `.java` as persistent (`--persist`) to avoid accepting the license for each launch.


### PR DESCRIPTION
Hello,

I propose to add the folder `~/.java` as a persist since the IntelliJ is using it to store the accepted license agreements.
This only affects the flatpak installation when running with a more restricted filesystem settings than the default `filesystem=host` (since this can be set by the user using CLI or Flatseal).

Thanks for all the work.