### PR TITLE
add arm64 build support, jetbrains bundles jbr built specifically for…

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Community.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Community.yaml
@@ -79,6 +79,8 @@ modules:
         url: https://www.gnupg.org/ftp/gcrypt/pinentry/pinentry-1.1.1.tar.bz2
 
   - name: idea
+    only-arches:
+      - x86_64
     buildsystem: simple
     build-commands:
       - install --directory --mode=0755 /app/idea-IC/
@@ -97,6 +99,33 @@ modules:
         x-checker-data:
           code: IIC
           type: jetbrains
+      - type: file
+        path: com.jetbrains.IntelliJ-IDEA-Community.desktop
+      - type: file
+        path: com.jetbrains.IntelliJ-IDEA-Community.metainfo.xml
+
+  - name: idea-arm64
+    only-arches:
+      - aarch64
+    buildsystem: simple
+    build-commands:
+      - install --directory --mode=0755 /app/idea-IC/
+      - tar --directory=/app/idea-IC/ --extract --file=ideaIC.tar.gz --gunzip --strip-components=1
+      - install -D --mode=0644 /app/idea-IC/bin/idea.svg /app/share/icons/hicolor/scalable/apps/com.jetbrains.IntelliJ-IDEA-Community.svg
+      - install -D --mode=0755 entrypoint.sh /app/bin/idea
+      - install -D --mode=0644 --target-directory=/app/share/applications/ com.jetbrains.IntelliJ-IDEA-Community.desktop
+      - install -D --mode=0644 --target-directory=/app/share/metainfo/ com.jetbrains.IntelliJ-IDEA-Community.metainfo.xml
+    sources:
+      - type: file
+        path: entrypoint.sh
+      - type: file
+        dest-filename: ideaIC.tar.gz
+        sha256: cbd25b7e80f9b0b16574b2baee674df596fd6bdafac3fc51ae12fb0ed2836eac
+        url: https://download.jetbrains.com/idea/ideaIC-2022.3.1-aarch64.tar.gz
+        x-checker-data:
+          code: IIC
+          type: jetbrains
+          arch: aarch64
       - type: file
         path: com.jetbrains.IntelliJ-IDEA-Community.desktop
       - type: file

--- a/com.jetbrains.IntelliJ-IDEA-Community.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Community.yaml
@@ -125,7 +125,6 @@ modules:
         x-checker-data:
           code: IIC
           type: jetbrains
-          arch: aarch64
       - type: file
         path: com.jetbrains.IntelliJ-IDEA-Community.desktop
       - type: file


### PR DESCRIPTION
This patch add the new ARM64 build published by JetBrains. 

This PR fixes the bundled version of JBR on arm64 as the default build comes with x86_64 JBR which fails to start on arm64 machines.

It requires a separate patch to flatpak-external-data-checker to handle automatic updates to external files to provide support for different architectures published by JetBrains. Separate PR has been posted to that project.



