### PR TITLE
Fix not being able to connect to PulseAudio

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Community.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Community.yaml
@@ -10,11 +10,13 @@ finish-args:
   - --filesystem=xdg-run/gnupg:ro
   - --filesystem=host
   - --filesystem=xdg-run/keyring
+  - --filesystem=xdg-run/pipewire-0:ro
   - --share=ipc
   - --share=network
   - --socket=ssh-auth
   - --socket=wayland
   - --socket=x11
+  - --socket=pulseaudio
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=org.freedesktop.Flatpak
   - --talk-name=org.freedesktop.secrets


### PR DESCRIPTION
Hello!

We had a couple people having an issue with the flatpak version of intellij not being able to play sounds in libGDX. (Fedora, Pop!_OS)

https://github.com/libgdx/libgdx/issues/6875

```
> Task :lwjgl3:run
[ALSOFT] (EE) Failed to connect PipeWire event context (errno: 112)
ALSA lib ../../pulse/pulse.c:242:(pulse_connect) PulseAudio: Unable to connect: Connection refused
```

After investigating it turns out the flatpak image is missing the `--socket=pulseaudio` command.


This didn't fix the issue fully as afterwards sound was playing, however there was still an error message in the console
```
> Task :lwjgl3:run
[ALSOFT] (EE) Failed to connect PipeWire event context (errno: 112)
```

Looks like passing the pipewire socket `--filesystem=xdg-run/pipewire-0:ro` to the flatpak image made it work fully without errors.

---

The following test project was tested and created with Pop!_OS 22.04:

Clone the repo, open it up in intellij, and then execute the `run` gradle task with java 17.

https://github.com/lyze237/FlatpakAudioBugExample
