### PR TITLE
remove idea.properties workaround

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Community.json
+++ b/com.jetbrains.IntelliJ-IDEA-Community.json
@@ -15,7 +15,6 @@
         "--env=JAVA_HOME=/app/extra/idea-IC/jbr",
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.freedesktop.secrets",
-        "--env=IDEA_PROPERTIES=/app/bin/idea.properties",
         "--filesystem=xdg-run/app/com.discordapp.Discord:create",
         "--filesystem=xdg-run/docker",
         "--filesystem=xdg-run/gnupg",
@@ -29,7 +28,6 @@
             "name": "idea",
             "build-commands": [
                 "install -D apply_extra ${FLATPAK_DEST}/bin/apply_extra",
-                "install -Dm644 -t ${FLATPAK_DEST}/bin/ idea.properties",
                 "install -Dm644 -t ${FLATPAK_DEST}/share/applications/ ${FLATPAK_ID}.desktop",
                 "install -Dm644 -t ${FLATPAK_DEST}/share/metainfo/ ${FLATPAK_ID}.metainfo.xml",
                 "install -Dm644 -t ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/ ${FLATPAK_ID}.svg"
@@ -73,10 +71,6 @@
                 {
                     "type": "file",
                     "path": "com.jetbrains.IntelliJ-IDEA-Community.metainfo.xml"
-                },
-                {
-                    "type": "file",
-                    "path": "idea.properties"
                 },
                 {
                     "type": "file",

--- a/com.jetbrains.IntelliJ-IDEA-Community.metainfo.xml
+++ b/com.jetbrains.IntelliJ-IDEA-Community.metainfo.xml
@@ -10,6 +10,8 @@
     <url type="bugtracker">https://youtrack.jetbrains.com/issues/IDEA/</url>
     <url type="help">https://www.jetbrains.com/idea/documentation/</url>
     <url type="homepage">https://www.jetbrains.com/idea/</url>
+    <url type="vcs-browser">https://github.com/JetBrains/intellij-community</url>
+    <url type="contact">https://www.jetbrains.com/company/contacts</url>
     <developer id="com.jetbrains">
         <name>JetBrains s.r.o.</name>
     </developer>

--- a/idea.properties
+++ b/idea.properties
@@ -1,6 +1,0 @@
-# =================================================================================================
-#   USER-DEFINED PROPERTIES/SETTINGS
-# =================================================================================================
-# Disable Chrome sandboxing due to invalid user and permissions
-# YouTrack issue: https://youtrack.jetbrains.com/issue/IDEA-313202
-ide.browser.jcef.sandbox.enable=false


### PR DESCRIPTION
As https://youtrack.jetbrains.com/issue/IJPL-59368/IDE-crashes-due-to-chrome-sandbox-is-owned-by-root-and-has-mode-error-when-IDE-is-launching-the-JCEF-in-a-sandbox is fixed, workaround no more necessary